### PR TITLE
feat: add favorites functionality with localStorage

### DIFF
--- a/web/src/components/VideoCard.tsx
+++ b/web/src/components/VideoCard.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { useVideo } from '../hooks/useVideo';
+import { useFavorites } from '../hooks/useFavorites';
 import type { VideoPlaylistItem } from '../types/video.types';
 
 interface VideoCardProps {
@@ -8,7 +9,9 @@ interface VideoCardProps {
 
 export const VideoCard = ({ video }: VideoCardProps) => {
   const { selectedVideo, setSelectedVideo } = useVideo();
+  const { toggleFavorite, isFavorite } = useFavorites();
   const isSelected = selectedVideo?.id === video.id;
+  const isFav = isFavorite(video.id);
   const cardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -34,6 +37,11 @@ export const VideoCard = ({ video }: VideoCardProps) => {
     }
   };
 
+  const handleFavoriteClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    toggleFavorite(video.id);
+  };
+
   return (
     <div
       ref={cardRef}
@@ -47,13 +55,32 @@ export const VideoCard = ({ video }: VideoCardProps) => {
       onClick={handleClick}
       onKeyDown={handleKeyDown}
     >
-      <div className="aspect-video bg-gray-100">
+      <div className="relative aspect-video bg-gray-100">
         <img
           src={video.snippet.thumbnails.high.url}
           alt={video.snippet.title}
           loading="lazy"
           className="w-full h-full object-cover"
         />
+        <button
+          onClick={handleFavoriteClick}
+          aria-label={isFav ? 'Remove from favorites' : 'Add to favorites'}
+          className="absolute top-2 right-2 p-2 bg-white/90 hover:bg-white rounded-full shadow-lg transition-all duration-200 hover:scale-110 active:scale-95"
+        >
+          <svg
+            className={`w-5 h-5 transition-colors ${
+              isFav ? 'fill-red-500 stroke-red-500' : 'fill-none stroke-gray-700'
+            }`}
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+            />
+          </svg>
+        </button>
       </div>
       <div className="p-4">
         <h3 className="font-semibold text-gray-900 line-clamp-2 mb-2">

--- a/web/src/hooks/useFavorites.ts
+++ b/web/src/hooks/useFavorites.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+
+const FAVORITES_KEY = 'english-playlist-favorites';
+
+export const useFavorites = () => {
+  const [favorites, setFavorites] = useState<string[]>(() => {
+    try {
+      const stored = localStorage.getItem(FAVORITES_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
+    } catch (error) {
+      console.error('Failed to save favorites to localStorage:', error);
+    }
+  }, [favorites]);
+
+  const toggleFavorite = (videoId: string) => {
+    setFavorites((prev) =>
+      prev.includes(videoId) ? prev.filter((id) => id !== videoId) : [...prev, videoId]
+    );
+  };
+
+  const isFavorite = (videoId: string) => favorites.includes(videoId);
+
+  const clearFavorites = () => setFavorites([]);
+
+  return {
+    favorites,
+    toggleFavorite,
+    isFavorite,
+    clearFavorites,
+    favoritesCount: favorites.length,
+  };
+};

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { VideoList } from '../components/VideoList';
 import { VideoPlayer } from '../components/VideoPlayer';
 import { SortDropdown } from '../components/SortDropdown';
+import { useFavorites } from '../hooks/useFavorites';
 import { apiClient } from '../services/api';
 import { sortVideos } from '../utils/sortVideos';
 import type { VideoPlaylistItem, SortOption } from '../types/video.types';
@@ -13,6 +14,8 @@ export const Home = () => {
   const [syncing, setSyncing] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortOption, setSortOption] = useState<SortOption>('position');
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
+  const { favorites, favoritesCount } = useFavorites();
 
   useEffect(() => {
     const loadVideos = async () => {
@@ -50,12 +53,16 @@ export const Home = () => {
   const filteredAndSortedVideos = useMemo(() => {
     if (!videos) return [];
 
-    const filtered = videos.filter((video) =>
+    let filtered = videos.filter((video) =>
       video.snippet.title.toLowerCase().includes(searchQuery.toLowerCase())
     );
 
+    if (showFavoritesOnly) {
+      filtered = filtered.filter((video) => favorites.includes(video.id));
+    }
+
     return sortVideos(filtered, sortOption);
-  }, [videos, searchQuery, sortOption]);
+  }, [videos, searchQuery, sortOption, showFavoritesOnly, favorites]);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -111,7 +118,28 @@ export const Home = () => {
 
         <section aria-label="Video gallery">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-bold text-gray-900">Video Gallery</h2>
+            <div className="flex items-center gap-4">
+              <h2 className="text-2xl font-bold text-gray-900">Video Gallery</h2>
+              <button
+                onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
+                className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
+                  showFavoritesOnly
+                    ? 'bg-red-100 text-red-700 hover:bg-red-200'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+                aria-label={showFavoritesOnly ? 'Show all videos' : 'Show favorites only'}
+              >
+                <svg
+                  className={`w-5 h-5 ${showFavoritesOnly ? 'fill-red-500' : 'fill-gray-500'}`}
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+                </svg>
+                <span className="text-sm font-medium">
+                  {showFavoritesOnly ? 'Favorites' : 'All'} ({showFavoritesOnly ? favoritesCount : videos?.length || 0})
+                </span>
+              </button>
+            </div>
             <div className="flex items-center gap-4">
               <div className="w-full max-w-[200px]">
                 <SortDropdown value={sortOption} onChange={setSortOption} />


### PR DESCRIPTION
## Summary
- Add ability to mark videos as favorites with persistent storage
- Create useFavorites hook with localStorage integration
- Add heart button to video cards with visual feedback
- Implement filter to show only favorited videos
- Display favorites count in toggle button

## Changes
- **useFavorites Hook**: Custom hook managing favorites state with localStorage persistence
- **VideoCard**: Heart icon button with red fill when favorited
- **Home Page**: Filter toggle button to switch between all videos and favorites only
- **User Experience**: Smooth transitions, accessible ARIA labels, persistent across sessions

## Features
- Click heart icon to add/remove favorites
- Toggle between "All" and "Favorites" view
- Favorites persist in localStorage
- Real-time count display
- Works seamlessly with search and sort filters