### PR TITLE
perf: implement React.memo for component optimization

### DIFF
--- a/web/src/components/SortDropdown.tsx
+++ b/web/src/components/SortDropdown.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { SortOption } from '../types/video.types';
 
 interface SortDropdownProps {
@@ -5,7 +6,7 @@ interface SortDropdownProps {
   onChange: (value: SortOption) => void;
 }
 
-export const SortDropdown = ({ value, onChange }: SortDropdownProps) => {
+const SortDropdownComponent = ({ value, onChange }: SortDropdownProps) => {
   return (
     <div className="relative">
       <label htmlFor="sort-select" className="sr-only">
@@ -43,3 +44,5 @@ export const SortDropdown = ({ value, onChange }: SortDropdownProps) => {
     </div>
   );
 };
+
+export const SortDropdown = memo(SortDropdownComponent);

--- a/web/src/components/VideoCard.tsx
+++ b/web/src/components/VideoCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, memo } from 'react';
 import { useVideo } from '../hooks/useVideo';
 import { useFavorites } from '../hooks/useFavorites';
 import type { VideoPlaylistItem } from '../types/video.types';
@@ -7,7 +7,7 @@ interface VideoCardProps {
   video: VideoPlaylistItem;
 }
 
-export const VideoCard = ({ video }: VideoCardProps) => {
+const VideoCardComponent = ({ video }: VideoCardProps) => {
   const { selectedVideo, setSelectedVideo } = useVideo();
   const { toggleFavorite, isFavorite } = useFavorites();
   const isSelected = selectedVideo?.id === video.id;
@@ -93,3 +93,5 @@ export const VideoCard = ({ video }: VideoCardProps) => {
     </div>
   );
 };
+
+export const VideoCard = memo(VideoCardComponent);

--- a/web/src/components/VideoCardSkeleton.tsx
+++ b/web/src/components/VideoCardSkeleton.tsx
@@ -1,4 +1,6 @@
-export const VideoCardSkeleton = () => {
+import { memo } from 'react';
+
+const VideoCardSkeletonComponent = () => {
   return (
     <div
       className="bg-white rounded-lg shadow-md overflow-hidden animate-pulse opacity-70"
@@ -18,3 +20,5 @@ export const VideoCardSkeleton = () => {
     </div>
   );
 };
+
+export const VideoCardSkeleton = memo(VideoCardSkeletonComponent);

--- a/web/src/components/VideoList.tsx
+++ b/web/src/components/VideoList.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { VideoPlaylistItem } from '../types/video.types';
 import { VideoCard } from './VideoCard';
 import { VideoCardSkeleton } from './VideoCardSkeleton';
@@ -7,7 +8,7 @@ interface VideoListProps {
   loading?: boolean;
 }
 
-export const VideoList = ({ videos, loading = false }: VideoListProps) => {
+const VideoListComponent = ({ videos, loading = false }: VideoListProps) => {
   if (loading) {
     return (
       <section aria-label="Loading videos" aria-busy="true">
@@ -64,3 +65,5 @@ export const VideoList = ({ videos, loading = false }: VideoListProps) => {
     </section>
   );
 };
+
+export const VideoList = memo(VideoListComponent);

--- a/web/src/components/VideoPlayer.tsx
+++ b/web/src/components/VideoPlayer.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import ReactPlayer from 'react-player';
 import { useVideo } from '../hooks/useVideo';
 import { VideoPlayerSkeleton } from './VideoPlayerSkeleton';
@@ -6,7 +7,7 @@ interface VideoPlayerProps {
   loading?: boolean;
 }
 
-export const VideoPlayer = ({ loading = false }: VideoPlayerProps) => {
+const VideoPlayerComponent = ({ loading = false }: VideoPlayerProps) => {
   const { selectedVideo } = useVideo();
 
   if (loading) {
@@ -81,3 +82,5 @@ export const VideoPlayer = ({ loading = false }: VideoPlayerProps) => {
     </article>
   );
 };
+
+export const VideoPlayer = memo(VideoPlayerComponent);


### PR DESCRIPTION
## Summary

Implement React.memo memoization across key frontend components to optimize rendering performance and prevent unnecessary re-renders.

### Changes

This PR includes 5 atomic commits, each implementing memoization for a specific component:

1. **VideoCard** - Prevents re-render when other cards update or parent re-renders
2. **VideoList** - Optimizes list rendering with prop comparison  
3. **VideoPlayer** - Avoids re-rendering when loading state unchanged
4. **VideoCardSkeleton** - Static component optimization (no props)
5. **SortDropdown** - Prevents re-render on parent updates

### Performance Improvements

- ✅ Reduced re-renders during video selection
- ✅ Optimized filter and sort operations  
- ✅ Better skeleton loading performance
- ✅ Improved ReactPlayer stability (prevents unnecessary re-initialization)

### Testing

- [x] Components render correctly
- [x] Video selection works as expected
- [x] Filters and sorting maintain functionality
- [x] No visual regressions