### PR TITLE
Fix: Add bidirectional sorting support

### DIFF
--- a/web/src/types/video.types.ts
+++ b/web/src/types/video.types.ts
@@ -56,4 +56,4 @@ export interface VideoPlaylistResponse {
   pageInfo: VideoPageInfo;
 }
 
-export type SortOption = 'position' | 'date' | 'title';
+export type SortOption = 'position' | 'date-desc' | 'date-asc' | 'title-asc' | 'title-desc';

--- a/web/src/utils/sortVideos.ts
+++ b/web/src/utils/sortVideos.ts
@@ -10,15 +10,26 @@ export const sortVideos = (
     case 'position':
       return sortedVideos.sort((a, b) => a.snippet.position - b.snippet.position);
 
-    case 'date':
+    case 'date-desc':
       return sortedVideos.sort(
         (a, b) =>
           new Date(b.snippet.publishedAt).getTime() - new Date(a.snippet.publishedAt).getTime()
       );
 
-    case 'title':
+    case 'date-asc':
+      return sortedVideos.sort(
+        (a, b) =>
+          new Date(a.snippet.publishedAt).getTime() - new Date(b.snippet.publishedAt).getTime()
+      );
+
+    case 'title-asc':
       return sortedVideos.sort((a, b) =>
         a.snippet.title.localeCompare(b.snippet.title, 'en', { sensitivity: 'base' })
+      );
+
+    case 'title-desc':
+      return sortedVideos.sort((a, b) =>
+        b.snippet.title.localeCompare(a.snippet.title, 'en', { sensitivity: 'base' })
       );
 
     default:


### PR DESCRIPTION
## Summary
Fixes a critical bug where the sorting dropdown had options that weren't implemented in the sorting logic, causing silent failures when users selected "Date (Oldest First)" or "Title (Z-A)".

## Changes
- **Updated `SortOption` type** in `src/types/video.types.ts`:
  - Changed from: `'position' | 'date' | 'title'`
  - Changed to: `'position' | 'date-desc' | 'date-asc' | 'title-asc' | 'title-desc'`

- **Enhanced `sortVideos` utility** in `src/utils/sortVideos.ts`:
  - Added `date-asc`: Sort videos from oldest to newest
  - Added `title-desc`: Sort videos in reverse alphabetical order (Z-A)
  - Maintained existing functionality for `position`, `date-desc`, and `title-asc`

## Bug Details
The SortDropdown component offered 5 sorting options, but the sorting logic only supported 3. This meant:
- "Date (Oldest First)" would not work
- "Title (Z-A)" would not work
- Users would see no change when selecting these options

## Testing
- ✅ All sort options now properly implemented
- ✅ TypeScript types match dropdown options
- ✅ No breaking changes to existing functionality